### PR TITLE
Fix for efficient way to add emoji in recent page

### DIFF
--- a/lib/src/github/ankushsachdeva/emojicon/EmojiconRecentsManager.java
+++ b/lib/src/github/ankushsachdeva/emojicon/EmojiconRecentsManager.java
@@ -64,12 +64,12 @@ public class EmojiconRecentsManager extends ArrayList<Emojicon> {
     }
 
     public void push(Emojicon object) {
-        // FIXME totally inefficient way of adding the emoji to the adapter
-        // TODO this should be probably replaced by a deque
         if (contains(object)) {
-            super.remove(object);
+            // rotate the array list starting from index 0 to index of Emojicon object
+            Collections.rotate(super.subList(0, super.indexOf(object)+1), 1);
+        } else {
+            add(0, object);
         }
-        add(0, object);
     }
 
     @Override


### PR DESCRIPTION
Instead of removing emoji object from current index in array list & then adding it to 0 index, rotate sub array list by 1.
Sub array list starts from index 0 to current index of emoji object in the main/super array list.
